### PR TITLE
highlight links over 70 chars

### DIFF
--- a/syntax/nasl.vim
+++ b/syntax/nasl.vim
@@ -259,7 +259,7 @@ syn keyword naslKeyword include break local_var global_var
 " Special characters and strings
 syn match   naslSpecial	display contained "\\\(x\x\+\|\o\{1,3}\|.\|$\)"
 syn match   naslLongLink display contained "\"http.\{67,}\"" containedin=naslString
-syn region  naslString	start=+L\="+ end=+"+ contains=@Spell
+syn region  naslString	start=+L\="+ end=+"+ contains=@Spell,naslLongLink
 syn region  naslString	start=+L\='+ skip=+\\\\\|\\"+ end=+'+ contains=naslSpecial,@Spell,naslLongLink
 syn keyword naslSpecial report_verbosity report_paranoia description thorough_tests
 


### PR DESCRIPTION
Debated on highlighting VS syntax checking. I think highlighting as soon as it happens provides greater utility to a plugin writer.

Note: The 70 character limitation is for legacy versions of Nessus.
