### PR TITLE
Added 'continue' keyword to naslKeyword list

### DIFF
--- a/syntax/nasl.vim
+++ b/syntax/nasl.vim
@@ -295,7 +295,7 @@ syn keyword naslLibGlobal UNKNOWN_VER
 
 " Keywords extracted from nasl_grammar.tab.c
 syn keyword naslKeyword if else for while repeat until foreach function return
-syn keyword naslKeyword include break local_var global_var
+syn keyword naslKeyword include break local_var global_var continue
 
 " Special characters and strings
 syn match   naslSpecialChar display contained "\\\(x\x\+\|\o\{1,3}\|.\|$\)"


### PR DESCRIPTION
This is a duplicate of  #4. I had forgotten that the machine I made the commit on had its clock set back 2 months, because _reasons_.

The erroneous commit, and the merge commit merging it into master, have been removed from history.
